### PR TITLE
enforce reply ordering

### DIFF
--- a/jdwproxy/src/IRP.java
+++ b/jdwproxy/src/IRP.java
@@ -32,10 +32,6 @@ public abstract class IRP<T> {
 		m_subscribers.add(irp);
 	}
 
-	private void remove_subscriber(IRP irp) {
-		m_subscribers.remove(irp);
-	}
-
 	public void subscribe(IRP irp) {
 		if (m_dependants == null) {
 			m_dependants = new HashSet<>();
@@ -54,11 +50,6 @@ public abstract class IRP<T> {
 		}
 		if (status == 0) {
 			m_isReady = true;
-			if (m_dependants != null) {
-				for (IRP dependant : getDependantsSnapshot()) {
-					dependant.remove_subscriber(this);
-				}
-			}
 			if (m_subscribers != null) {
 				for (IRP subscriber : m_subscribers.toArray(new IRP[0])) {
 					subscriber.alert();


### PR DESCRIPTION
Previously the JDWP proxy will use out-of-order optimization, take the following scenario for example:
1. debugger issued COMMAND 1
2. proxy forwarded COMMAND 1 to stub/debuggee
3. debugger issued COMMAND 2
4. proxy retrieved REPLY 2 from cache and sent back to debugger
5. proxy received REPLY 1 from stub/debuggee
6. proxy sent REPLY 1 to debugger
In this way, debugger will receive REPLY 2 before REPLY 1.

This seems to make the VSCode Java Debugger confused, now making change to enforce the reply ordering.